### PR TITLE
Support animated PNG in preview window

### DIFF
--- a/FlowVision/Sources/Common/ImageProcess.swift
+++ b/FlowVision/Sources/Common/ImageProcess.swift
@@ -555,7 +555,7 @@ func getImageThumb(url: URL, size oriSize: NSSize? = nil, refSize: NSSize? = nil
         return getVideoThumbnailFFmpeg(for: url)
     }else if (globalVar.HandledImageAndRawExtensions+["pdf"]).contains(url.pathExtension.lowercased()) { //处理其它缩略图
         //使用原图的格式
-        if ["gif", "svg"].contains(url.pathExtension.lowercased()){
+        if ["png", "gif", "svg"].contains(url.pathExtension.lowercased()){
             return NSImage(contentsOf: url)
         }
         //若指定了大小则特殊处理


### PR DESCRIPTION
## Overview
This pull request adds support for animated PNGs in the preview window. With this change, animated PNGs will be displayed in their original form, similar to GIFs, instead of generating thumbnails.

## Changes
Modified the getImageThumb function to display the original animated PNG instead of generating a thumbnail, same as GIF.

## Potential Issues
There may be performance degradation when displaying PNGs, especially with large files or multiple animated PNGs.

## Testing
Verified the preview window correctly displays animated PNG files.
The following images was used for testing:
https://apng.onevcat.com/demo/

Before
https://github.com/user-attachments/assets/e019a72f-bbe5-4c28-a3a5-c9871b8abc1c

After
https://github.com/user-attachments/assets/6bfff77e-8ec0-45ae-9283-ceb3467fb18e

