### PR TITLE
add Finder tag support with colored dots on thumbnails and full-screen view

### DIFF
--- a/FlowVision.xcodeproj/project.pbxproj
+++ b/FlowVision.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		F7DECD6D2D00939300ECC099 /* CustomEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DECD6C2D00938600ECC099 /* CustomEffectView.swift */; };
 		F7E0B31C2DBF0F55007CBD17 /* SDWebImageWebPCoder in Frameworks */ = {isa = PBXBuildFile; productRef = F7E0B31B2DBF0F55007CBD17 /* SDWebImageWebPCoder */; };
 		F7F600462E1E095400ED8536 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F600452E1E094900ED8536 /* Tag.swift */; };
+		F7F600482E1E095500ED8536 /* FinderTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F600472E1E094A00ED8536 /* FinderTag.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -175,6 +176,7 @@
 		F7DECD6C2D00938600ECC099 /* CustomEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEffectView.swift; sourceTree = "<group>"; };
 		F7E65E342C09C7F100ACC4C0 /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
 		F7F600452E1E094900ED8536 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		F7F600472E1E094A00ED8536 /* FinderTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderTag.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,6 +201,7 @@
 				F73865E12C37C0A300837FE4 /* Enum.swift */,
 				F73865E72C37C26C00837FE4 /* FFmpegKit.swift */,
 				F73865D82C37BBCB00837FE4 /* GlobalVariable.swift */,
+				F7F600472E1E094A00ED8536 /* FinderTag.swift */,
 				F73865E32C37C11B00837FE4 /* ImageProcess.swift */,
 				F76E2EFD2C3B765C0031B0B4 /* Log.swift */,
 				F73865DA2C37BC1500837FE4 /* RefCode.swift */,
@@ -444,6 +447,7 @@
 				F77098972F0E436800E7D164 /* LargeImage.swift in Sources */,
 				F74D55582F0E493700C9AB85 /* LayoutProfileConfig.swift in Sources */,
 				F7F600462E1E095400ED8536 /* Tag.swift in Sources */,
+				F7F600482E1E095500ED8536 /* FinderTag.swift in Sources */,
 				F73865D92C37BBCB00837FE4 /* GlobalVariable.swift in Sources */,
 				F74D555A2F0E49AB00C9AB85 /* AutoScrollPlay.swift in Sources */,
 				F73865E62C37C1AA00837FE4 /* DrawingView.swift in Sources */,

--- a/FlowVision/Sources/Common/DataModel.swift
+++ b/FlowVision/Sources/Common/DataModel.swift
@@ -460,6 +460,7 @@ class FileModel {
     var rotate: Int = 0
     var imageInfo: ImageInfo?
     var getThumbFailed = false
+    var finderTags: [String] = []
 }
 
 class DirModel {

--- a/FlowVision/Sources/Common/FinderTag.swift
+++ b/FlowVision/Sources/Common/FinderTag.swift
@@ -1,0 +1,68 @@
+//
+//  FinderTag.swift
+//  FlowVision
+//
+
+import Foundation
+import Cocoa
+
+struct FinderTag {
+    let name: String
+    let color: NSColor
+
+    static let all: [FinderTag] = [
+        FinderTag(name: "Red", color: NSColor(red: 0.94, green: 0.22, blue: 0.22, alpha: 1.0)),
+        FinderTag(name: "Orange", color: NSColor(red: 0.96, green: 0.56, blue: 0.12, alpha: 1.0)),
+        FinderTag(name: "Yellow", color: NSColor(red: 0.98, green: 0.84, blue: 0.16, alpha: 1.0)),
+        FinderTag(name: "Green", color: NSColor(red: 0.30, green: 0.78, blue: 0.30, alpha: 1.0)),
+        FinderTag(name: "Blue", color: NSColor(red: 0.22, green: 0.47, blue: 0.94, alpha: 1.0)),
+        FinderTag(name: "Purple", color: NSColor(red: 0.62, green: 0.35, blue: 0.87, alpha: 1.0)),
+        FinderTag(name: "Gray", color: NSColor(red: 0.60, green: 0.60, blue: 0.60, alpha: 1.0)),
+    ]
+
+    var dotImage: NSImage {
+        NSImage(size: NSSize(width: 12, height: 12), flipped: false) { rect in
+            self.color.setFill()
+            NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+            return true
+        }
+    }
+
+    static func byName(_ name: String) -> FinderTag? {
+        all.first { $0.name == name }
+    }
+}
+
+enum FinderTagHelper {
+    static func readTags(from url: URL) -> [String] {
+        guard let values = try? url.resourceValues(forKeys: [.tagNamesKey]) else { return [] }
+        return values.tagNames ?? []
+    }
+
+    static func writeTags(_ tags: [String], to url: URL) {
+        try? (url as NSURL).setResourceValue(tags, forKey: .tagNamesKey)
+    }
+
+    /// returns `true` if the tag was added, `false` if removed
+    @discardableResult
+    static func toggleTag(_ tagName: String, on urls: [URL]) -> Bool {
+        let allHaveTag = urls.allSatisfy { readTags(from: $0).contains(tagName) }
+        let adding = !allHaveTag
+        for url in urls {
+            var tags = readTags(from: url)
+            if adding {
+                if !tags.contains(tagName) { tags.append(tagName) }
+            } else {
+                tags.removeAll { $0 == tagName }
+            }
+            writeTags(tags, to: url)
+        }
+        return adding
+    }
+
+    static func removeAllTags(from urls: [URL]) {
+        for url in urls {
+            writeTags([], to: url)
+        }
+    }
+}

--- a/FlowVision/Sources/ViewController.swift
+++ b/FlowVision/Sources/ViewController.swift
@@ -156,6 +156,7 @@ class PublicVar{
     var customZoomRatio: Double = 1.0
     var customZoomStep: Double = 0.1
     var currentTag:String? = nil
+    var finderTagFilter: String? = nil
 
     // 可一键切换的配置
     // Configuration that can be switched with one key

--- a/FlowVision/Sources/ViewControllerExtension/EventHandler.swift
+++ b/FlowVision/Sources/ViewControllerExtension/EventHandler.swift
@@ -229,6 +229,49 @@ extension ViewController {
         UserDefaults.standard.setValue(tag, forKey: "currentTag")
     }
     
+    func handleToggleFinderTag(_ tagName: String) {
+        let urls = publicVar.selectedUrls()
+        guard !urls.isEmpty else { return }
+
+        let added = FinderTagHelper.toggleTag(tagName, on: urls)
+        refreshFinderTagsForVisibleItems()
+
+        if let tag = FinderTag.byName(tagName) {
+            let action = added ? "+" : "-"
+            coreAreaView.showInfo("\(action) \(tag.name)", timeOut: 0.8, cannotBeCleard: false)
+        }
+    }
+
+    func refreshFinderTagsForVisibleItems() {
+        if let collectionView = collectionView {
+            for item in collectionView.visibleItems() {
+                if let item = item as? CustomCollectionViewItem {
+                    if let url = URL(string: item.file.path) {
+                        item.file.finderTags = FinderTagHelper.readTags(from: url)
+                    }
+                    item.refreshFinderTagDots()
+                }
+            }
+        }
+        if publicVar.isInLargeView, let url = URL(string: largeImageView.file.path) {
+            largeImageView.file.finderTags = FinderTagHelper.readTags(from: url)
+            largeImageView.refreshFinderTagDots()
+        }
+    }
+
+    func toggleFinderTagFilter(_ tagName: String?) {
+        if tagName == nil || publicVar.finderTagFilter == tagName {
+            publicVar.finderTagFilter = nil
+            coreAreaView.showInfo(NSLocalizedString("Show All", comment: "显示全部"), timeOut: 0.8, cannotBeCleard: false)
+        } else {
+            publicVar.finderTagFilter = tagName
+            if let tagName = tagName, let tag = FinderTag.byName(tagName) {
+                coreAreaView.showInfo(NSLocalizedString("Filter", comment: "筛选") + ": \(tag.name)", timeOut: 0.8, cannotBeCleard: false)
+            }
+        }
+        refreshCollectionView(needLoadThumbPriority: true)
+    }
+
     func handleTagging(){
         
         let urls = publicVar.selectedUrls()

--- a/FlowVision/Sources/ViewControllerExtension/KeyShortcut.swift
+++ b/FlowVision/Sources/ViewControllerExtension/KeyShortcut.swift
@@ -298,7 +298,13 @@ extension ViewController {
                 }
                 return nil
             }
-            
+
+            if ["1","2","3","4","5","6","7"].contains(characters) && isOnlyCommandPressed {
+                let index = Int(characters)! - 1
+                handleToggleFinderTag(FinderTag.all[index].name)
+                return nil
+            }
+
             // 检查按键是否是 Command+Shift+"N" 键
             // Check if key is Command+Shift+"N"
             if characters == "n" && isCommandPressed && !isAltPressed && !isCtrlPressed && isShiftPressed {

--- a/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
+++ b/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
@@ -709,7 +709,8 @@ extension ViewController {
         }
         
         largeImageView.file=file
-        
+        largeImageView.refreshFinderTagDots()
+
         if justChangeLargeImageViewFile {return}
   
         let url=URL(string:file.path)!

--- a/FlowVision/Sources/Views/CustomCollectionView.swift
+++ b/FlowVision/Sources/Views/CustomCollectionView.swift
@@ -126,9 +126,34 @@ class CustomCollectionView: NSCollectionView {
                                                         keyEquivalent: "")
                     
                     menu.addItem(newMenuItem)
-            
+
                     menu.addItem(NSMenuItem.separator())
-                    
+
+                    let filterMenu = NSMenu()
+                    let filterMenuItem = NSMenuItem(title: NSLocalizedString("Filter by Finder Tag", comment: "按Finder标签筛选"), action: nil, keyEquivalent: "")
+                    filterMenuItem.submenu = filterMenu
+
+                    let currentFilter = getViewController(self)?.publicVar.finderTagFilter
+
+                    for tag in FinderTag.all {
+                        let item = filterMenu.addItem(withTitle: NSLocalizedString(tag.name, comment: ""), action: #selector(actFilterByFinderTag(_:)), keyEquivalent: "")
+                        item.representedObject = tag.name
+                        if currentFilter == tag.name {
+                            item.state = .on
+                        }
+                        item.image = tag.dotImage
+                    }
+
+                    filterMenu.addItem(NSMenuItem.separator())
+                    let showAllItem = filterMenu.addItem(withTitle: NSLocalizedString("Show All", comment: "显示全部"), action: #selector(actClearFinderTagFilter), keyEquivalent: "")
+                    if currentFilter == nil {
+                        showAllItem.state = .on
+                    }
+
+                    menu.addItem(filterMenuItem)
+
+                    menu.addItem(NSMenuItem.separator())
+
                     let actionItemRefresh = menu.addItem(withTitle: NSLocalizedString("Refresh", comment: "刷新"), action: #selector(actRefresh), keyEquivalent: "r")
                     actionItemRefresh.keyEquivalentModifierMask = [.command]
                     
@@ -186,5 +211,14 @@ class CustomCollectionView: NSCollectionView {
     // Add action handler method for new text file
     @objc func actNewTextFile() {
         getViewController(self)?.handleNewTextFile()
+    }
+
+    @objc func actFilterByFinderTag(_ sender: NSMenuItem) {
+        guard let tagName = sender.representedObject as? String else { return }
+        getViewController(self)?.toggleFinderTagFilter(tagName)
+    }
+
+    @objc func actClearFinderTagFilter() {
+        getViewController(self)?.toggleFinderTagFilter(nil)
     }
 }


### PR DESCRIPTION
I have mainly implemented it for myself, but have found many people in the linked issue also having the same struggle.

Fixes #54 

Features:

- Read/write macOS Finder tags on files with colored dot indicators on both grid thumbnails and large image view
- Toggle tags via Cmd+1–7 keyboard shortcuts or right-click context menus ("Finder Tags" submenu)
- Filter files by Finder tag from the background context menu ("Filter by Finder Tag" submenu)