### PR TITLE
Add pixel-perfect scaling mode for image preview

### DIFF
--- a/FlowVision/Sources/AppDelegate.swift
+++ b/FlowVision/Sources/AppDelegate.swift
@@ -199,6 +199,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenuItemVa
         if let scrollMouseWheelToZoom = UserDefaults.standard.value(forKey: "scrollMouseWheelToZoom") as? Bool {
             globalVar.scrollMouseWheelToZoom = scrollMouseWheelToZoom
         }
+        if let pixelPerfectImageScaling = UserDefaults.standard.value(forKey: "pixelPerfectImageScaling") as? Bool {
+            globalVar.pixelPerfectImageScaling = pixelPerfectImageScaling
+        }
         if let scrollSensitivity = UserDefaults.standard.value(forKey: "scrollSensitivity") as? Double {
             globalVar.scrollSensitivity = scrollSensitivity
         }
@@ -1255,4 +1258,3 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenuItemVa
         getMainViewController()?.toggleSearchOverlay()
     }
 }
-

--- a/FlowVision/Sources/Common/GlobalVariable.swift
+++ b/FlowVision/Sources/Common/GlobalVariable.swift
@@ -98,6 +98,7 @@ class GlobalVar{
     var isEnterKeyToOpen = false
     var clickEdgeToSwitchImage = false
     var scrollMouseWheelToZoom = false
+    var pixelPerfectImageScaling = false
     var openLastFolder = true
     var homeFolder = "file:///"
     var keepFilterStateWhenSwitchFolder = false
@@ -206,4 +207,3 @@ func getSystemVolumeName() -> String? {
         return nil
     }
 }
-

--- a/FlowVision/Sources/Common/ImageProcess.swift
+++ b/FlowVision/Sources/Common/ImageProcess.swift
@@ -1110,9 +1110,45 @@ func getAnimateImage(url: URL, size: NSSize? = nil, rotate: Int = 0) -> NSImage?
     return nil
 }
 
-func getResizedImage(url: URL, size oriSize: NSSize, rotate: Int = 0, isRawUseEmbeddedThumb: Bool) -> NSImage? {
+private let pixelPerfectUpscaleSourceMaxDimension: CGFloat = 2048
+private let pixelPerfectUpscaleSourceMaxPixels: CGFloat = 4_194_304
+private let pixelPerfectUpscaleOutputMaxPixels: CGFloat = 16_777_216
+
+func shouldUsePixelPerfectUpscaledImage(originalPixelSize: NSSize, targetSize: NSSize, screenScale: CGFloat) -> Bool {
+    let targetPixelWidth = round(targetSize.width * max(screenScale, 1))
+    let targetPixelHeight = round(targetSize.height * max(screenScale, 1))
+    let originalPixelCount = originalPixelSize.width * originalPixelSize.height
+    let targetPixelCount = targetPixelWidth * targetPixelHeight
+
+    guard targetPixelWidth >= originalPixelSize.width,
+          targetPixelHeight >= originalPixelSize.height else {
+        return false
+    }
+
+    guard max(originalPixelSize.width, originalPixelSize.height) <= pixelPerfectUpscaleSourceMaxDimension,
+          originalPixelCount <= pixelPerfectUpscaleSourceMaxPixels,
+          targetPixelCount <= pixelPerfectUpscaleOutputMaxPixels else {
+        return false
+    }
+
+    return true
+}
+
+func getPixelPerfectUpscaledImage(url: URL, size: NSSize, rotate: Int = 0, isRawUseEmbeddedThumb: Bool, screenScale: CGFloat) -> NSImage? {
+    return getResizedImage(
+        url: url,
+        size: size,
+        rotate: rotate,
+        isRawUseEmbeddedThumb: isRawUseEmbeddedThumb,
+        interpolationQuality: .none,
+        renderScale: max(screenScale, 1)
+    )
+}
+
+func getResizedImage(url: URL, size oriSize: NSSize, rotate: Int = 0, isRawUseEmbeddedThumb: Bool, interpolationQuality: CGInterpolationQuality = .high, renderScale: CGFloat = 2) -> NSImage? {
     
     let size: NSSize = NSSize(width: round(oriSize.width), height: round(oriSize.height))
+    let effectiveRenderScale = max(renderScale, 1)
 
     // 根据配置优先尝试使用Exif内嵌缩略图
     // Try to use Exif embedded thumbnail first according to configuration
@@ -1150,9 +1186,9 @@ func getResizedImage(url: URL, size oriSize: NSSize, rotate: Int = 0, isRawUseEm
     case 5, 6, 7, 8:
         // 图像旋转90度或270度
         // Image rotated 90 or 270 degrees
-        pointSize = CGSize(width: size.height * 2, height: size.width * 2)
+        pointSize = CGSize(width: size.height * effectiveRenderScale, height: size.width * effectiveRenderScale)
     default:
-        pointSize = CGSize(width: size.width * 2, height: size.height * 2)
+        pointSize = CGSize(width: size.width * effectiveRenderScale, height: size.height * effectiveRenderScale)
     }
     
 
@@ -1211,7 +1247,7 @@ func getResizedImage(url: URL, size oriSize: NSSize, rotate: Int = 0, isRawUseEm
                             bytesPerRow: 0,
                             space: colorSpace,
                             bitmapInfo: adjustedBitmapInfo)
-    context?.interpolationQuality = .high
+    context?.interpolationQuality = interpolationQuality
 
     // 调整原点到中心并应用旋转
     // Adjust origin to center and apply rotation
@@ -2257,8 +2293,8 @@ class LargeImageProcessor {
 //        return getResizedImage(url: url, size: size, rotate: rotate)
 //    }
     
-    static func getImageCache(url: URL, size: NSSize, rotate: Int = 0, ver: Int, useOriginalImage: Bool, isHDR: Bool, isRawUseEmbeddedThumb: Bool, needWaitWhenSame: Bool = true) -> NSImage? {
-        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)" as NSString
+    static func getImageCache(url: URL, size: NSSize, rotate: Int = 0, ver: Int, useOriginalImage: Bool, isHDR: Bool, isRawUseEmbeddedThumb: Bool, pixelPerfectUpscale: Bool = false, screenScale: CGFloat = 2, needWaitWhenSame: Bool = true) -> NSImage? {
+        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)_ppu\(pixelPerfectUpscale)_scale\(Int(round(screenScale * 100)))" as NSString
         // print(cacheKey)
         
         // 先检查缓存中是否已有图像（包括nil情况）
@@ -2305,7 +2341,11 @@ class LargeImageProcessor {
                     image = NSImage(contentsOf: url)?.rotated(by: CGFloat(-90*rotate))
                 }
             }else{
-                image = getResizedImage(url: url, size: size, rotate: rotate, isRawUseEmbeddedThumb: isRawUseEmbeddedThumb)
+                if pixelPerfectUpscale {
+                    image = getPixelPerfectUpscaledImage(url: url, size: size, rotate: rotate, isRawUseEmbeddedThumb: isRawUseEmbeddedThumb, screenScale: screenScale)
+                } else {
+                    image = getResizedImage(url: url, size: size, rotate: rotate, isRawUseEmbeddedThumb: isRawUseEmbeddedThumb)
+                }
                 if image == nil {
                     image = NSImage(contentsOf: url)?.rotated(by: CGFloat(-90*rotate))
                 }
@@ -2334,8 +2374,8 @@ class LargeImageProcessor {
     
     // 检查缓存中是否有图像（且不是nil）
     // Check if image exists in cache (and is not nil)
-    static func isImageCached(url: URL, size: NSSize, rotate: Int = 0, ver: Int, isHDR: Bool, isRawUseEmbeddedThumb: Bool) -> Bool {
-        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)" as NSString
+    static func isImageCached(url: URL, size: NSSize, rotate: Int = 0, ver: Int, isHDR: Bool, isRawUseEmbeddedThumb: Bool, pixelPerfectUpscale: Bool = false, screenScale: CGFloat = 2) -> Bool {
+        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)_ppu\(pixelPerfectUpscale)_scale\(Int(round(screenScale * 100)))" as NSString
         if let cachedWrapper = cache.object(forKey: cacheKey) {
             return cachedWrapper.image != nil
         }
@@ -2344,8 +2384,8 @@ class LargeImageProcessor {
     
     // 检查缓存中是否有图像，有的话则返回
     // Check if image exists in cache, return it if found
-    static func isImageCachedAndGet(url: URL, size: NSSize, rotate: Int = 0, ver: Int, isHDR: Bool, isRawUseEmbeddedThumb: Bool) -> NSImage? {
-        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)" as NSString
+    static func isImageCachedAndGet(url: URL, size: NSSize, rotate: Int = 0, ver: Int, isHDR: Bool, isRawUseEmbeddedThumb: Bool, pixelPerfectUpscale: Bool = false, screenScale: CGFloat = 2) -> NSImage? {
+        let cacheKey = "\(url.absoluteString)_\(size.width)x\(size.height)_\(rotate)_v\(ver)_hdr\(isHDR)_embeded\(isRawUseEmbeddedThumb)_ppu\(pixelPerfectUpscale)_scale\(Int(round(screenScale * 100)))" as NSString
         if let cachedWrapper = cache.object(forKey: cacheKey) {
             return cachedWrapper.image
         }

--- a/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
+++ b/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
@@ -733,6 +733,7 @@ extension ViewController {
         }
         
         largeImageView.file=file
+        largeImageView.refreshPixelPerfectRendering()
         largeImageView.refreshFinderTagDots()
         largeImageView.refreshRatingStars()
 
@@ -809,6 +810,13 @@ extension ViewController {
             // When original image actual size is smaller than view size, display at actual size
             if !publicVar.isLargeImageFitWindow && originalSize.width<largeSize.width*scale && !triggeredByLongPress {
                 largeSize=NSSize(width: originalSize.width/scale, height: originalSize.height/scale)
+            }
+            
+            if globalVar.pixelPerfectImageScaling &&
+               !publicVar.isZoomLocked &&
+               (publicVar.isLargeImageFitWindow || triggeredByLongPress),
+               let pixelPerfectSize = largeImageView.pixelPerfectFitSize(maxBounds: maxBounds.size) {
+                largeSize = pixelPerfectSize
             }
             
             // 缩放锁定

--- a/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
+++ b/FlowVision/Sources/ViewControllerExtension/LargeImage.swift
@@ -652,11 +652,16 @@ extension ViewController {
             // Integer scaling
             largeSize = NSSize(width: round(largeSize.width), height: round(largeSize.height))
             
+            let pixelPerfectUpscale = globalVar.pixelPerfectImageScaling &&
+                !isHDR &&
+                !["gif", "svg", "ai"].contains(url.pathExtension.lowercased()) &&
+                shouldUsePixelPerfectUpscaledImage(originalPixelSize: originalSize, targetSize: largeSize, screenScale: scale)
+
             // 不进行过大缩放，内存炸了
             // Do not perform excessive scaling, memory will explode
             var doNotGenResized=false
             if largeSize.width*scale>=originalSize.width && largeSize.height*scale>=originalSize.height {
-                doNotGenResized=true
+                doNotGenResized = !pixelPerfectUpscale
             }
             
             // 如果RAW使用Exif内嵌缩略图，则不使用原图（进行缩放）
@@ -673,7 +678,7 @@ extension ViewController {
 
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else { return }
-                _ = LargeImageProcessor.getImageCache(url: url, size: largeSize, rotate: 0, ver: file.ver, useOriginalImage: doNotGenResized, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb, needWaitWhenSame: false)
+                _ = LargeImageProcessor.getImageCache(url: url, size: largeSize, rotate: 0, ver: file.ver, useOriginalImage: doNotGenResized, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb, pixelPerfectUpscale: pixelPerfectUpscale && !doNotGenResized, screenScale: scale, needWaitWhenSame: false)
             }
             
         }
@@ -838,11 +843,17 @@ extension ViewController {
             // Integer scaling
             largeSize = NSSize(width: round(largeSize.width), height: round(largeSize.height))
             
+            let pixelPerfectUpscale = globalVar.pixelPerfectImageScaling &&
+                !isHDR &&
+                rotate == 0 &&
+                !["gif", "svg", "ai"].contains(url.pathExtension.lowercased()) &&
+                shouldUsePixelPerfectUpscaledImage(originalPixelSize: originalSize, targetSize: largeSize, screenScale: scale)
+
             // 不进行过大缩放，内存炸了
             // Do not perform excessive scaling, memory will explode
             var doNotGenResized=false
             if largeSize.width*scale>=originalSize.width && largeSize.height*scale>=originalSize.height {
-                doNotGenResized=true
+                doNotGenResized = !pixelPerfectUpscale
             }
             
             // 但如果是旋转，还是缩放占用更小
@@ -892,7 +903,8 @@ extension ViewController {
             
             // 检查是否有大图缓存
             // Check for large image cache
-            var preGetImageCache = file.type == .image ? LargeImageProcessor.isImageCachedAndGet(url: url, size: largeSize, rotate: rotate, ver: file.ver, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb) : nil
+            let usePixelPerfectUpscale = pixelPerfectUpscale && !doNotGenResized
+            var preGetImageCache = file.type == .image ? LargeImageProcessor.isImageCachedAndGet(url: url, size: largeSize, rotate: rotate, ver: file.ver, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb, pixelPerfectUpscale: usePixelPerfectUpscale, screenScale: scale) : nil
             if forceRefresh {preGetImageCache = nil}
             let isImageCached = preGetImageCache != nil
             
@@ -963,7 +975,7 @@ extension ViewController {
                     // Rendering at actual target resolution has poor quality, observed that double interpolation on 1080P screen renders similar to using original image directly, so even if scale==1, size here is not divided by 2
                     var largeImage: NSImage?
                     if resetSize && !forceRefresh {
-                        largeImage=LargeImageProcessor.getImageCache(url: url, size: largeSize, rotate: rotate, ver: file.ver, useOriginalImage: doNotGenResized, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb)
+                        largeImage=LargeImageProcessor.getImageCache(url: url, size: largeSize, rotate: rotate, ver: file.ver, useOriginalImage: doNotGenResized, isHDR: isHDR, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb, pixelPerfectUpscale: usePixelPerfectUpscale, screenScale: scale)
                     }else{
                         if isHDR {
                             largeImage = getHDRImage(url: url, size: doNotGenResized ? nil : largeSize, rotate: rotate)
@@ -976,7 +988,11 @@ extension ViewController {
                                 largeImage = NSImage(contentsOf: url)?.rotated(by: CGFloat(-90*rotate))
                             }
                         }else{
-                            largeImage = getResizedImage(url: url, size: largeSize, rotate: rotate, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb)
+                            if usePixelPerfectUpscale {
+                                largeImage = getPixelPerfectUpscaledImage(url: url, size: largeSize, rotate: rotate, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb, screenScale: scale)
+                            } else {
+                                largeImage = getResizedImage(url: url, size: largeSize, rotate: rotate, isRawUseEmbeddedThumb: publicVar.isRawUseEmbeddedThumb)
+                            }
                             if largeImage == nil {
                                 lastResizeFailed = true
                                 largeImage = NSImage(contentsOf: url)?.rotated(by: CGFloat(-90*rotate))

--- a/FlowVision/Sources/Views/CustomImageView.swift
+++ b/FlowVision/Sources/Views/CustomImageView.swift
@@ -193,6 +193,13 @@ class CustomThumbImageView: BorderedImageView {
 
 class CustomLargeImageView: IntegerImageView {
     var isMirroredH: Bool = false
+    var isPixelPerfectEnabled: Bool = false {
+        didSet {
+            needsDisplay = true
+            layer?.magnificationFilter = isPixelPerfectEnabled ? .nearest : .linear
+            layer?.minificationFilter = isPixelPerfectEnabled ? .nearest : .linear
+        }
+    }
     
     override var image: NSImage? {
         get { return super.image }
@@ -211,5 +218,17 @@ class CustomLargeImageView: IntegerImageView {
         if let img = super.image {
             super.image = img.flippedHorizontally()
         }
+    }
+    
+    override func draw(_ dirtyRect: NSRect) {
+        guard isPixelPerfectEnabled, let image = image else {
+            super.draw(dirtyRect)
+            return
+        }
+        
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current?.imageInterpolation = .none
+        image.draw(in: bounds, from: .zero, operation: .sourceOver, fraction: 1.0, respectFlipped: true, hints: [.interpolation: NSImageInterpolation.none])
+        NSGraphicsContext.restoreGraphicsState()
     }
 }

--- a/FlowVision/Sources/Views/CustomImageView.swift
+++ b/FlowVision/Sources/Views/CustomImageView.swift
@@ -195,7 +195,6 @@ class CustomLargeImageView: IntegerImageView {
     var isMirroredH: Bool = false
     var isPixelPerfectEnabled: Bool = false {
         didSet {
-            needsDisplay = true
             layer?.magnificationFilter = isPixelPerfectEnabled ? .nearest : .linear
             layer?.minificationFilter = isPixelPerfectEnabled ? .nearest : .linear
         }
@@ -218,17 +217,5 @@ class CustomLargeImageView: IntegerImageView {
         if let img = super.image {
             super.image = img.flippedHorizontally()
         }
-    }
-    
-    override func draw(_ dirtyRect: NSRect) {
-        guard isPixelPerfectEnabled, let image = image else {
-            super.draw(dirtyRect)
-            return
-        }
-        
-        NSGraphicsContext.saveGraphicsState()
-        NSGraphicsContext.current?.imageInterpolation = .none
-        image.draw(in: bounds, from: .zero, operation: .sourceOver, fraction: 1.0, respectFlipped: true, hints: [.interpolation: NSImageInterpolation.none])
-        NSGraphicsContext.restoreGraphicsState()
     }
 }

--- a/FlowVision/Sources/Views/LargeImageView.swift
+++ b/FlowVision/Sources/Views/LargeImageView.swift
@@ -100,6 +100,7 @@ class LargeImageView: NSView {
         imageView.imageScaling = .scaleAxesIndependently
         imageView.wantsLayer = true
         imageView.animates=true
+        imageView.isPixelPerfectEnabled = globalVar.pixelPerfectImageScaling
         self.addSubview(imageView)
 
         videoView = LargeAVPlayerView(frame: self.bounds)
@@ -1181,6 +1182,64 @@ class LargeImageView: NSView {
         }
     }
     
+    func refreshPixelPerfectRendering() {
+        imageView.isPixelPerfectEnabled = globalVar.pixelPerfectImageScaling
+        imageView.needsDisplay = true
+    }
+    
+    private func pixelPerfectBaseSize() -> NSSize? {
+        let size = customZoomSize()
+        guard size.width > 0, size.height > 0 else { return nil }
+        return size
+    }
+    
+    func pixelPerfectFitSize(maxBounds: NSSize) -> NSSize? {
+        guard globalVar.pixelPerfectImageScaling,
+              let baseSize = pixelPerfectBaseSize() else { return nil }
+        
+        let multiplier = floor(min(maxBounds.width / baseSize.width, maxBounds.height / baseSize.height))
+        guard multiplier >= 1 else { return nil }
+        
+        return NSSize(width: baseSize.width * multiplier, height: baseSize.height * multiplier)
+    }
+    
+    private func nextPixelPerfectZoomSize(direction: Int) -> NSSize? {
+        guard globalVar.pixelPerfectImageScaling,
+              let baseSize = pixelPerfectBaseSize() else { return nil }
+        
+        let ratio = imageView.frame.width / baseSize.width
+        if direction > 0 {
+            let nextMultiplier = max(1, Int(floor(ratio + 0.0001)) + 1)
+            return NSSize(width: baseSize.width * CGFloat(nextMultiplier), height: baseSize.height * CGFloat(nextMultiplier))
+        } else if direction < 0, ratio > 1 {
+            let nextMultiplier = max(1, Int(ceil(ratio - 0.0001)) - 1)
+            return NSSize(width: baseSize.width * CGFloat(nextMultiplier), height: baseSize.height * CGFloat(nextMultiplier))
+        }
+        
+        return nil
+    }
+    
+    private func setZoomSize(_ newSize: NSSize, anchor locationInImageView: NSPoint) {
+        let zoomFactorWidth = newSize.width / imageView.frame.width
+        let zoomFactorHeight = newSize.height / imageView.frame.height
+        
+        imageView.frame.size = newSize
+        imageView.frame.origin.x -= locationInImageView.x * (zoomFactorWidth - 1)
+        imageView.frame.origin.y -= locationInImageView.y * (zoomFactorHeight - 1)
+    }
+    
+    private func snapToNearestPixelPerfectZoom(anchor locationInImageView: NSPoint) {
+        guard globalVar.pixelPerfectImageScaling,
+              let baseSize = pixelPerfectBaseSize() else { return }
+        
+        let ratio = imageView.frame.width / baseSize.width
+        guard ratio >= 1 else { return }
+        
+        let snappedMultiplier = max(1, Int(round(ratio)))
+        let snappedSize = NSSize(width: baseSize.width * CGFloat(snappedMultiplier), height: baseSize.height * CGFloat(snappedMultiplier))
+        setZoomSize(snappedSize, anchor: locationInImageView)
+    }
+    
     func zoom(direction: Int = 0){
         if file.type == .video {return}
         
@@ -1199,25 +1258,41 @@ class LargeImageView: NSView {
         let locationInImageView = imageView.convert(locationInView, from: self)
         
         if direction > 0 {
-            if isExceedZoomLimit(enlarge: true, width: imageView.frame.size.width, height: imageView.frame.size.height){
-                return
+            if let pixelPerfectSize = nextPixelPerfectZoomSize(direction: direction) {
+                if isExceedZoomLimit(enlarge: true, width: pixelPerfectSize.width, height: pixelPerfectSize.height){
+                    return
+                }
+                hasZoomedByWheel=true
+                setZoomSize(pixelPerfectSize, anchor: locationInImageView)
+            } else {
+                if isExceedZoomLimit(enlarge: true, width: imageView.frame.size.width, height: imageView.frame.size.height){
+                    return
+                }
+                hasZoomedByWheel=true
+                
+                imageView.frame.size.width *= zoomFactor
+                imageView.frame.size.height *= zoomFactor
+                imageView.frame.origin.x -= (locationInImageView.x * (zoomFactor - 1))
+                imageView.frame.origin.y -= (locationInImageView.y * (zoomFactor - 1))
             }
-            hasZoomedByWheel=true
-            
-            imageView.frame.size.width *= zoomFactor
-            imageView.frame.size.height *= zoomFactor
-            imageView.frame.origin.x -= (locationInImageView.x * (zoomFactor - 1))
-            imageView.frame.origin.y -= (locationInImageView.y * (zoomFactor - 1))
         } else if direction < 0 {
-            if isExceedZoomLimit(enlarge: false, width: imageView.frame.size.width, height: imageView.frame.size.height){
-                return
+            if let pixelPerfectSize = nextPixelPerfectZoomSize(direction: direction) {
+                if isExceedZoomLimit(enlarge: false, width: pixelPerfectSize.width, height: pixelPerfectSize.height){
+                    return
+                }
+                hasZoomedByWheel=true
+                setZoomSize(pixelPerfectSize, anchor: locationInImageView)
+            } else {
+                if isExceedZoomLimit(enlarge: false, width: imageView.frame.size.width, height: imageView.frame.size.height){
+                    return
+                }
+                hasZoomedByWheel=true
+                
+                imageView.frame.size.width /= zoomFactor
+                imageView.frame.size.height /= zoomFactor
+                imageView.frame.origin.x += (locationInImageView.x * (1 - 1/zoomFactor))
+                imageView.frame.origin.y += (locationInImageView.y * (1 - 1/zoomFactor))
             }
-            hasZoomedByWheel=true
-            
-            imageView.frame.size.width /= zoomFactor
-            imageView.frame.size.height /= zoomFactor
-            imageView.frame.origin.x += (locationInImageView.x * (1 - 1/zoomFactor))
-            imageView.frame.origin.y += (locationInImageView.y * (1 - 1/zoomFactor))
         }
         
         // 同步编辑画布位置和大小
@@ -1249,13 +1324,7 @@ class LargeImageView: NSView {
             let zoomSize=customZoomSize()
             let locationInView = self.convert(point, from: nil)
             let locationInImageView = imageView.convert(locationInView, from: self)
-            
-            let zoomFactorWidth = zoomSize.width / imageView.frame.width
-            let zoomFactorHeight = zoomSize.height / imageView.frame.height
-            
-            imageView.frame.size = zoomSize
-            imageView.frame.origin.x -= (locationInImageView.x * (zoomFactorWidth - 1))
-            imageView.frame.origin.y -= (locationInImageView.y * (zoomFactorHeight - 1))
+            setZoomSize(zoomSize, anchor: locationInImageView)
             
             // 同步编辑画布位置和大小
             // Sync editing canvas position and size
@@ -1282,6 +1351,7 @@ class LargeImageView: NSView {
             }
         case .ended:
             initialScale *= magnification
+            snapToNearestPixelPerfectZoom(anchor: gesture.location(in: imageView))
             getViewController(self)?.changeLargeImage(firstShowThumb: false, resetSize: false, triggeredByLongPress: false, isByZoom: true)
         default:
             break
@@ -1874,25 +1944,41 @@ class LargeImageView: NSView {
             let locationInImageView = imageView.convert(locationInView, from: self)
             
             if event.deltaY > 0 {
-                if isExceedZoomLimit(enlarge: true, width: imageView.frame.size.width, height: imageView.frame.size.height){
-                    return
+                if let pixelPerfectSize = nextPixelPerfectZoomSize(direction: 1) {
+                    if isExceedZoomLimit(enlarge: true, width: pixelPerfectSize.width, height: pixelPerfectSize.height){
+                        return
+                    }
+                    hasZoomedByWheel=true
+                    setZoomSize(pixelPerfectSize, anchor: locationInImageView)
+                } else {
+                    if isExceedZoomLimit(enlarge: true, width: imageView.frame.size.width, height: imageView.frame.size.height){
+                        return
+                    }
+                    hasZoomedByWheel=true
+                    
+                    imageView.frame.size.width *= zoomFactor
+                    imageView.frame.size.height *= zoomFactor
+                    imageView.frame.origin.x -= (locationInImageView.x * (zoomFactor - 1))
+                    imageView.frame.origin.y -= (locationInImageView.y * (zoomFactor - 1))
                 }
-                hasZoomedByWheel=true
-                
-                imageView.frame.size.width *= zoomFactor
-                imageView.frame.size.height *= zoomFactor
-                imageView.frame.origin.x -= (locationInImageView.x * (zoomFactor - 1))
-                imageView.frame.origin.y -= (locationInImageView.y * (zoomFactor - 1))
             } else if event.deltaY < 0 {
-                if isExceedZoomLimit(enlarge: false, width: imageView.frame.size.width, height: imageView.frame.size.height){
-                    return
+                if let pixelPerfectSize = nextPixelPerfectZoomSize(direction: -1) {
+                    if isExceedZoomLimit(enlarge: false, width: pixelPerfectSize.width, height: pixelPerfectSize.height){
+                        return
+                    }
+                    hasZoomedByWheel=true
+                    setZoomSize(pixelPerfectSize, anchor: locationInImageView)
+                } else {
+                    if isExceedZoomLimit(enlarge: false, width: imageView.frame.size.width, height: imageView.frame.size.height){
+                        return
+                    }
+                    hasZoomedByWheel=true
+                    
+                    imageView.frame.size.width /= zoomFactor
+                    imageView.frame.size.height /= zoomFactor
+                    imageView.frame.origin.x += (locationInImageView.x * (1 - 1/zoomFactor))
+                    imageView.frame.origin.y += (locationInImageView.y * (1 - 1/zoomFactor))
                 }
-                hasZoomedByWheel=true
-                
-                imageView.frame.size.width /= zoomFactor
-                imageView.frame.size.height /= zoomFactor
-                imageView.frame.origin.x += (locationInImageView.x * (1 - 1/zoomFactor))
-                imageView.frame.origin.y += (locationInImageView.y * (1 - 1/zoomFactor))
             }
             // log(imageView.frame.size,imageView.frame.origin)
             

--- a/FlowVision/Sources/WindowController.swift
+++ b/FlowVision/Sources/WindowController.swift
@@ -1445,6 +1445,10 @@ extension WindowController: NSToolbarDelegate {
                 panWhenZoomed.keyEquivalentModifierMask = []
                 panWhenZoomed.state = viewController.publicVar.isPanWhenZoomed ? .on : .off
                 
+                let pixelPerfectScaling = menu.addItem(withTitle: NSLocalizedString("Pixel Perfect Scaling", comment: "像素完美缩放"), action: #selector(togglePixelPerfectScaling), keyEquivalent: "")
+                pixelPerfectScaling.keyEquivalentModifierMask = []
+                pixelPerfectScaling.state = globalVar.pixelPerfectImageScaling ? .on : .off
+                
                 let panZoomInfo = menu.addItem(withTitle: NSLocalizedString("Readme...", comment: "说明..."), action: #selector(panZoomInfo), keyEquivalent: "")
                 
                 // let customZoomRatio = menu.addItem(withTitle: NSLocalizedString("Custom Zoom Ratio...", comment: "自定义缩放比例..."), action: #selector(showCustomZoomRatioDialog), keyEquivalent: "")
@@ -1593,6 +1597,21 @@ extension WindowController: NSToolbarDelegate {
     @objc func togglePanWhenZoomed(_ sender: NSMenuItem){
         guard let viewController = contentViewController as? ViewController else {return}
         viewController.togglePanWhenZoomed()
+    }
+    
+    @objc func togglePixelPerfectScaling(_ sender: NSMenuItem){
+        globalVar.pixelPerfectImageScaling.toggle()
+        UserDefaults.standard.set(globalVar.pixelPerfectImageScaling, forKey: "pixelPerfectImageScaling")
+        
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            for windowController in appDelegate.windowControllers {
+                guard let viewController = windowController.contentViewController as? ViewController else { continue }
+                viewController.largeImageView.refreshPixelPerfectRendering()
+                if viewController.publicVar.isInLargeView && viewController.largeImageView.file.type == .image {
+                    viewController.changeLargeImage(firstShowThumb: false, resetSize: false, triggeredByLongPress: false, forceRefresh: true)
+                }
+            }
+        }
     }
     
     @objc func toggleRawUseEmbeddedThumb(_ sender: NSMenuItem){

--- a/bin/build_debug.sh
+++ b/bin/build_debug.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+xcodebuild \
+  -project FlowVision.xcodeproj \
+  -scheme FlowVision \
+  -configuration Debug \
+  -sdk macosx \
+  build

--- a/bin/build_dev.sh
+++ b/bin/build_dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+xcodebuild \
+  -project FlowVision.xcodeproj \
+  -scheme FlowVision \
+  -configuration Release \
+  -sdk macosx \
+  build \
+  CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
Introduce a pixel-perfect scaling option for large image preview so pixel art can be viewed without blur from smooth interpolation or arbitrary zoom ratios.

This adds a persisted toggle, applies nearest-neighbor rendering in the large image view, snaps zoom-in behavior to integer multiples of 100% when the mode is enabled, and prefers integer-multiple fit-to-window sizes where possible. The mode is exposed from the large-image menu and refreshes open viewers immediately when changed.

This keeps existing behavior for cases where the image must be displayed below 100%, since true pixel-perfect presentation is not possible while downscaling.


Current: 

<img width="926" height="718" alt="Screenshot 2026-04-18 at 19 13 38" src="https://github.com/user-attachments/assets/61f43e0c-c1cd-41cb-b1d7-9232f425734a" />


with "Pixel Perfect Scaling"

<img width="1253" height="768" alt="Screenshot 2026-04-18 at 19 14 24" src="https://github.com/user-attachments/assets/a21cc52e-62c2-42ed-a4b1-f6dc3c58a5e2" />
