### PR TITLE
Fix Trash handling on external volumes

### DIFF
--- a/FlowVision/Sources/ViewControllerExtension/FileOperation.swift
+++ b/FlowVision/Sources/ViewControllerExtension/FileOperation.swift
@@ -941,14 +941,10 @@ extension ViewController {
         alert.messageText = NSLocalizedString("Delete", comment: "删除")
         if isShiftPressed {
             alert.informativeText = NSLocalizedString("ask-to-delete-shift", comment: "你确定要将这些文件永久删除吗？此操作无法撤销。")
-        }else if VolumeManager.shared.isExternalVolume(urls.first!) {
-            alert.informativeText = NSLocalizedString("ask-to-delete-external", comment: "此目录不支持移动到废纸篓。将立即删除这些项目，此操作无法撤销。")
+        }else if ifHasPermission{
+            alert.informativeText = NSLocalizedString("ask-to-delete", comment: "你确定要将这些文件移动到废纸篓吗？")
         }else{
-            if ifHasPermission{
-                alert.informativeText = NSLocalizedString("ask-to-delete", comment: "你确定要将这些文件移动到废纸篓吗？")
-            }else{
-                alert.informativeText = NSLocalizedString("ask-to-delete-nopermission", comment: "你确定要将这些文件移动到废纸篓吗？(无权限)")
-            }
+            alert.informativeText = NSLocalizedString("ask-to-delete-nopermission", comment: "你确定要将这些文件移动到废纸篓吗？(无权限)")
         }
         alert.alertStyle = .warning
         alert.addButton(withTitle: NSLocalizedString("Delete", comment: "删除"))
@@ -958,7 +954,7 @@ extension ViewController {
         alert.icon = NSImage(named: NSImage.cautionName)
 
         var response: NSApplication.ModalResponse = .alertFirstButtonReturn
-        if isShowPrompt || !ifHasPermission || VolumeManager.shared.isExternalVolume(urls.first!) {
+        if isShowPrompt || !ifHasPermission {
             let StoreIsKeyEventEnabled = publicVar.isKeyEventEnabled
             publicVar.isKeyEventEnabled=false
             response = alert.runModal()


### PR DESCRIPTION
## Summary

- Use the standard Trash confirmation message for files on external volumes.
- Let the existing Command+Delete immediate action apply to external volumes.
- Preserve Shift+Delete as the permanent deletion path.

## Problem

FlowVision currently assumes every external volume lacks Trash support. This produces a permanent-deletion warning and forces a confirmation dialog for every external volume.

External APFS volumes can provide a writable per-user Trash directory. FlowVision's existing non-Shift deletion path already asks Finder to move files to Trash and falls back to `NSWorkspace.recycle` when Apple Events permission is unavailable. The warning can therefore describe permanent deletion while the implementation moves the file to Trash.

This change lets the existing Trash operation determine filesystem support. A failed Trash operation leaves the source file in place and records the error through the existing logging path.

Related to #184.

## Validation

- Parsed the modified Swift source with `swiftc -frontend -parse`.
- Completed a Release build with Xcode 16 on a GitHub macOS runner: https://github.com/cyriusweng/FlowVision/actions/runs/31312233422
- Runtime-tested Command+Delete with a disposable PNG on an external APFS volume; the file moved into the volume's per-user `.Trashes` directory through the immediate action.
